### PR TITLE
Hashtable is not available on gwt, replace it with object map

### DIFF
--- a/core/src/ch/asynk/gdx/boardgame/animations/FireAnimation.java
+++ b/core/src/ch/asynk/gdx/boardgame/animations/FireAnimation.java
@@ -1,12 +1,10 @@
 package ch.asynk.gdx.boardgame.animations;
 
-import java.util.Hashtable;
-import java.util.Map;
-
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.Pool;
 
 import ch.asynk.gdx.boardgame.FramedSprite;
@@ -47,7 +45,7 @@ public class FireAnimation implements Animation, Pool.Poolable
         }
     }
 
-    private static Map<String, Config> configs = new Hashtable<String, Config>();
+    private static ObjectMap<String, Config> configs = new ObjectMap<String, Config>();
 
     public static void register(final String name,
             int burstCount,


### PR DESCRIPTION
I hope it's the last PR for this topic
```
   Tracing compile failure path for type 'ch.asynk.gdx.boardgame.animations.FireAnimation'
      [ERROR] Errors in 'jar:file:/home/travis/.gradle/caches/modules-2/files-2.1/com.github.jeremyz/gdx-boardgame/master-SNAPSHOT/754312f9a3b10760edcf1b3787319b74294f735f/gdx-boardgame-master-SNAPSHOT-sources.jar!/ch/asynk/gdx/boardgame/animations/FireAnimation.java'
         [ERROR] Line 50: No source code is available for type java.util.Hashtable<K,V>; did you forget to inherit a required module?
   [ERROR] Aborting compile due to errors in some input files
```