### PR TITLE
Remove overridden taint method in assembly

### DIFF
--- a/core/src/ch/asynk/gdx/boardgame/ui/Assembly.java
+++ b/core/src/ch/asynk/gdx/boardgame/ui/Assembly.java
@@ -45,11 +45,6 @@ public abstract class Assembly extends Element
         return false;
     }
 
-    @Override public void taint()
-    {
-        children.forEach( c -> c.taint() );
-    }
-
     @Override public void draw(Batch batch)
     {
         if (tainted) computeGeometry();


### PR DESCRIPTION
Fixes an endless loop with parent.taint() inside elements, shouldn't break anything because taint is called inside draw anyway